### PR TITLE
fix: style module import error

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 // .storybook/preview.js
 import * as NextImage from 'next/image';
-import '../src/styles/globals.css';
+import '../src/styles/globals.scss';
 
 const OriginalNextImage = NextImage.default;
 

--- a/dependencies/storybook-theme-toggle/ToggleTheme.js
+++ b/dependencies/storybook-theme-toggle/ToggleTheme.js
@@ -51,6 +51,7 @@ var ToggleTheme = function ToggleTheme(_ref) {
     var iframe = document.getElementById('storybook-preview-iframe');
     var iframeDocument = iframe.contentDocument || ((_iframe$contentWindow = iframe.contentWindow) === null || _iframe$contentWindow === void 0 ? void 0 : _iframe$contentWindow.document);
     iframeDocument.documentElement.setAttribute('data-color-theme', isDark ? 'dark' : 'light');
+    iframeDocument.documentElement.setAttribute('style', 'height:100%');
   }, [isDark]);
   return /*#__PURE__*/_react["default"].createElement(_components.IconButton, {
     key: "theme-toggle",


### PR DESCRIPTION
<!-- Remove the text block if it is not used or necessary -->

## Description

- resolved sass file import error for storybook
- fix background colour display for half page in story toggle theme

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor/Revamp ( rewrite or restructure code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] I ran `npm run format`/`yarn format` before commit
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings

### Related Issue

<!-- issue goes here -->

- none

### Proposed Changes

- Update the dependency to the storybook theme toggle 
- Change file extension in the storybook config 

### Additional Info

<!-- any additional information or context -->

- none

### Screenshots

|              Original              |              Updated              |
| :--------------------------------: | :-------------------------------: |
| <!-- ** original screenshot ** --> | <!-- ** updated screenshot ** --> |
| <!-- ** original screenshot ** --> | <!-- ** updated screenshot ** --> |
