### PR TITLE
fix: compact card text overlap on image

### DIFF
--- a/src/components/common/NE_Card/NE_CompactCard/CompactCard.module.scss
+++ b/src/components/common/NE_Card/NE_CompactCard/CompactCard.module.scss
@@ -1,11 +1,10 @@
 .card {
   &-compact {
     width: 100%;
-    // max-width: 14.5rem; /* 232px */
     height: 6.5rem; /* 104px */
+    min-height: 6.5rem; /* 104px */
     display: flex;
     justify-content: space-between;
-    align-items: center;
     overflow: hidden;
     transition: all 0.2s ease;
   }
@@ -32,6 +31,7 @@
     &-upper-part {
       display: flex;
       flex-direction: column;
+      opacity: 0.9;
     }
     &-lowwer-part {
       display: flex;
@@ -74,5 +74,7 @@
     right: 5%;
     bottom: 10%;
     opacity: 0.8;
+    display: grid;
+    place-items: center;
   }
 }


### PR DESCRIPTION
<!-- Remove the text block if it is not used or necessary -->

## Description

<!-- Please include a summary of the change or which issue is fixed. -->

- compact card text is overlap with the card icon in the metric page

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor ( rewrite or restructure code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Data Results

- none

### Additional Info

<!-- any additional information or context -->

- none
